### PR TITLE
Upgrade all dependencies and modernize build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.release>21</maven.compiler.release>
 		<s3.bucket>s3://quetoo</s3.bucket>
 	</properties>
 
@@ -21,32 +20,32 @@
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
-			<version>1.3.1</version>
+			<version>1.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.14.0</version>
+			<version>2.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.5</version>
+			<version>3.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+			<version>4.5.14</version>
 		</dependency>
 		<dependency>
 			<groupId>io.reactivex.rxjava2</groupId>
 			<artifactId>rxjava</artifactId>
-			<version>2.1.4</version>
+			<version>2.2.21</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -57,7 +56,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.3</version>
+				<version>3.6.0</version>
 				<configuration>
 					<transformers>
 						<transformer
@@ -71,6 +70,12 @@
 							<includes>
 								<include>**</include>
 							</includes>
+						</filter>
+						<filter>
+							<artifact>*:*</artifact>
+							<excludes>
+								<exclude>META-INF/versions/**</exclude>
+							</excludes>
 						</filter>
 					</filters>
 				</configuration>
@@ -86,7 +91,7 @@
 			<plugin>
 				<groupId>com.github.wvengen</groupId>
 				<artifactId>proguard-maven-plugin</artifactId>
-				<version>2.0.13</version>
+				<version>2.6.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -101,11 +106,20 @@
 					<outputDirectory>${project.build.directory}</outputDirectory>
 					<proguardInclude>${basedir}/proguard.conf</proguardInclude>
 					<libs>
-						<lib>${java.home}/lib/rt.jar</lib>
-						<lib>${java.home}/lib/jsse.jar</lib>
+						<lib>${java.home}/jmods/java.base.jmod</lib>
+						<lib>${java.home}/jmods/java.desktop.jmod</lib>
+						<lib>${java.home}/jmods/java.xml.jmod</lib>
+						<lib>${java.home}/jmods/java.datatransfer.jmod</lib>
 					</libs>
 					<includeDependency>false</includeDependency>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>com.guardsquare</groupId>
+						<artifactId>proguard-base</artifactId>
+						<version>7.6.1</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
- Upgrade Java 8 -> 21 (using --release 21)
- Upgrade ProGuard 5.2.1 -> 7.6.1 (supports modern JDKs)
- Update ProGuard config for modular Java (jmods instead of rt.jar)
- Upgrade maven-shade-plugin 2.4.3 -> 3.6.0
- Upgrade proguard-maven-plugin 2.0.13 -> 2.6.1
- Upgrade dependencies to latest stable versions:
  * commons-cli: 1.3.1 -> 1.9.0
  * commons-io: 2.14.0 -> 2.18.0
  * commons-lang3: 3.5 -> 3.17.0
  * httpclient: 4.5.13 -> 4.5.14
  * rxjava: 2.1.4 -> 2.2.21
  * junit: 4.13.1 -> 4.13.2

Fixes build issues with modern JDKs. Requires Java 21+ runtime.