### PR TITLE
CI: Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 21
+        cache: maven
+
+    - name: Build
+      run: mvn -B package
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: quetoo-installer-small
+        path: target/quetoo-installer-small.jar


### PR DESCRIPTION
Builds the installer JAR with Maven + JDK 21 (Temurin), uploads `quetoo-installer-small.jar` as a workflow artifact.

- Uses `actions/setup-java` with Maven caching built-in
- Runs `mvn package` which triggers shade + ProGuard minification
- Artifact can be downloaded by the quetoo engine build workflow

---
*Draft PR for testing CI.*