### PR TITLE
Update actions to Node.js 24 and publish release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: 21
@@ -28,7 +28,19 @@ jobs:
       run: mvn -B package
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: quetoo-installer-small
         path: target/quetoo-installer-small.jar
+
+    - name: Publish release
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release delete latest --yes --cleanup-tag 2>/dev/null || true
+        gh release create latest \
+          --title "Latest Build" \
+          --notes "Automatically updated on every push to main." \
+          --prerelease \
+          target/quetoo-installer-small.jar


### PR DESCRIPTION
- Bump actions/checkout v4 → v6, actions/setup-java v4 → v5, actions/upload-artifact v4 → v6 for Node.js 24 compatibility
- Add release publishing: creates/updates a `latest` prerelease with `quetoo-installer-small.jar` on every push to main
- The quetoo build workflow can then download the JAR from: `https://github.com/jdolan/quetoo-installer-java/releases/latest/download/quetoo-installer-small.jar`